### PR TITLE
Use slice notation to solve "Working with Files"

### DIFF
--- a/rosalind_ini5.py
+++ b/rosalind_ini5.py
@@ -1,8 +1,4 @@
 def main(input):
     lines = input.split("\n")
-    results = [lines[i] for i in range(len(lines)) if i % 2]
-        
-    print "-" * 10    
-    for line in results:
-        print line 
-    print "-" * 10 
+    size = len(lines) + 1
+    return '\n'.join(lines[1:size:2]).strip()


### PR DESCRIPTION
You could leave out the second argument in the slice notation
since it defaults to "everything".

For instance

``` py
'\n'.join(lines[1:size:2]).strip()
'\n'.join(lines[1::2]).strip()
```

[Slice notation examples](http://stackoverflow.com/a/8865914/881224).

They are equivalent. But I like having the explicit `skip` variable
in there since it looks more explicit than a `::` character.
