### PR TITLE
Simplifies the command line entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The answer should post directly to the command line.
 
 ```
 $> cd ~/code/py/rosalind
-$> python solve.py rosalind_ini3 --downloads_directory=~/Desktop
+$> python solve.py ini3 --downloads_directory=~/Desktop
 ```
 
 My rosalind text files downloaded to my desktop, so I pass in that argument here.

--- a/solve.py
+++ b/solve.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     parser.add_argument(
         'problem_name',
         action='store',
-        help='the name of the file you downloaded for this problem, minus the extension'
+        help='the name of the file you downloaded for this problem, minus the extension and rosalind_'
     )
 
     parser.add_argument(
@@ -44,7 +44,8 @@ if __name__ == '__main__':
     )
 
     args = parser.parse_args()
-    rosalind_solver = importlib.import_module(args.problem_name)
-    rosalind_input = grab_input(args.problem_name + '.txt', args.downloads_directory)
+    problem_name = 'rosalind_' + args.problem_name
+    rosalind_solver = importlib.import_module(problem_name)
+    rosalind_input = grab_input(problem_name + '.txt', args.downloads_directory)
 
     print rosalind_solver.main(rosalind_input)


### PR DESCRIPTION
I was getting tired of constantly typing in or copy/pasting python solve.py rosalind_problem, especially because my fingers natually want to type 'ing' instead of 'ind'. Since all of the rosalind files start with 'rosalind_', I figured we can streamline the process a bit by not having to type it anymore.

I then began to come across the feeling that perhaps more time is spend figuring out how to change everything and explaining it in a commit message than will be saved by making the process easier. I imagine that feeling comes up often in this field. I suppose the answer is that spending the time to make something more efficient will help you write more efficiently automatically in future projects.
