### PR TITLE
Remove list comprehension that does not alter the list

### DIFF
--- a/rosalind_ini6.py
+++ b/rosalind_ini6.py
@@ -1,4 +1,4 @@
 def main(input):
     from collections import Counter
-    results = Counter([word for word in input.split()]) 
+    results = Counter(input.split())
     return '\n'.join(["%s %d" % (k, v) for k, v in results.items()])


### PR DESCRIPTION
If you write a list comprehension that simply iterates over the list, nothing
will change about that list. There's no difference between writing the list
out straight away vs. using a list comprehension this way.

``` py
>>> range(10)
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
>>> [x for x in range(10)] #  nothing is done to the list
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```
