### PR TITLE
Counters don't need sorted input

### DIFF
--- a/rosalind_dna.py
+++ b/rosalind_dna.py
@@ -1,4 +1,4 @@
 def main(input):
     from collections import Counter
-    results = dict(Counter(sorted(list(input))))
+    results = Counter(input)
     return " ".join(map(str, [results["A"], results["C"], results["G"], results["T"]]))


### PR DESCRIPTION
Also, the input as a string works just fine, there's no need to make it a list first.
Both are considered _iterables_. Take for instance, this code.

``` py
>>> name = 'andrew'
>>> len(name)
6
>>> len(list(name))
6
>>> for letter in name: #  the same as `for letter in list(name)`, etc., etc.
```

You can treat strings, dictionaries, lists, and tuples as containers that respond to `for` loops, can have `map`, `reduce`, etc. called on them. They also have indexing, meaning `'andrew'[0]` is the same as `list('andrew')[0]`.

Another note: you called `dict(sorted(list(input)))`, which means you're expecting a `dict` to do something special with sorted input. [This is never the case](http://code.activestate.com/recipes/52306-to-sort-a-dictionary/), since dictionaries have no concept of sorting!

> The concept of 'sort' applies only to a collection which has _order_ -- a sequence; a mapping (e.g. a dictionary) has NO order, thus it cannot be sorted. Still, its keys can be extracted as a list, which can then be sorted.

Dictionaries were designed for one thing -- lookups. Lookups aren't affected one way or the other if they're not in alphabetical order, so the designers of Python made it so that dictionaries ignored any preference to keep key/value pairs in the same order at any given time (this was to make dictionaries more performant). Thus, if you did manage to sort a dictionary, the next time you asked for it's representation, it very well may be in an entirely different order.
